### PR TITLE
Use environmental variable instead of hard code string

### DIFF
--- a/src/main/java/com/xxxx/example/Servlet04.java
+++ b/src/main/java/com/xxxx/example/Servlet04.java
@@ -20,7 +20,7 @@ public class Servlet04 extends HttpServlet{
         resp.setCharacterEncoding("UTF-8");
         resp.setContentType("application/json");
 
-        Database myDatabase = new Database("", "DatingAppStaging");
+        Database myDatabase = new Database(System.getenv("DatabaseConnectionString"), System.getenv("DatabaseCollection"));
 
         // Should probably move off this hardcoded 20 at some point
         List<Document> postDocs = myDatabase.find_latest_posts(20);

--- a/src/main/java/com/xxxx/example/servlet05.java
+++ b/src/main/java/com/xxxx/example/servlet05.java
@@ -17,7 +17,7 @@ public class servlet05 extends HttpServlet {
         String get = req.getParameter("text");
         String userName = req.getParameter("userName");
 
-        Database myDatabase = new Database("", "DatingAppStaging");
+        Database myDatabase = new Database(System.getenv("DatabaseConnectionString"), System.getenv("DatabaseCollection"));
         myDatabase.insert_post(userName, get);
         req.getRequestDispatcher("/ser06").forward(req,resp);
     }

--- a/src/main/java/com/xxxx/example/servlet06.java
+++ b/src/main/java/com/xxxx/example/servlet06.java
@@ -18,7 +18,7 @@ public class servlet06 extends HttpServlet {
     protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         resp.setCharacterEncoding("UTF-8");
         resp.setContentType("application/json");
-        Database myDatabase = new Database("", "DatingAppStaging");
+        Database myDatabase = new Database(System.getenv("DatabaseConnectionString"), System.getenv("DatabaseCollection"));
         List<Document> postDocs = myDatabase.find_latest_posts(1);
 
         // convert to a BsonArray

--- a/src/main/java/com/xxxx/example/servletDeleteGateway.java
+++ b/src/main/java/com/xxxx/example/servletDeleteGateway.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 public class servletDeleteGateway extends HttpServlet {
     @Override
     protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        Database myDatabase = new Database("", "DatingAppStaging");
+        Database myDatabase = new Database(System.getenv("DatabaseConnectionString"), System.getenv("DatabaseCollection"));
         String username = (String) req.getAttribute("username");
         String delete_id = (String) req.getAttribute("id");
         String status;

--- a/src/main/java/com/xxxx/example/servletLikePostGateway.java
+++ b/src/main/java/com/xxxx/example/servletLikePostGateway.java
@@ -21,7 +21,7 @@ public class servletLikePostGateway extends HttpServlet {
         String post_id = req.getParameter("post_id");
         String event_type = req.getParameter("event_type");
 
-        Database myDatabase = new Database("", "DatingAppStaging");
+        Database myDatabase = new Database(System.getenv("DatabaseConnectionString"), System.getenv("DatabaseCollection"));
         if(event_type.equals("liked")){
             myDatabase.like(current_user,post_id);
             req.getRequestDispatcher("/likePostResponseLike").forward(req,resp);

--- a/src/main/java/com/xxxx/example/servletLikeReply.java
+++ b/src/main/java/com/xxxx/example/servletLikeReply.java
@@ -11,12 +11,14 @@ import java.io.IOException;
 // The servletLikeReply class works as a controller and pass variables to gateway.
 // Not yet functioning (to be added later)
 public class servletLikeReply extends HttpServlet {
+    private Database myDatabase;
+
     @Override
     protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         String user = req.getParameter("user");
         String replyID = req.getParameter("replyID");
         String status = "success";
-        Database myDatabase = new Database("", "DatingAppStaging");
+        Database myDatabase = new Database(System.getenv("DatabaseConnectionString"), System.getenv("DatabaseCollection"));
 
         req.setAttribute("status", status);
         req.getRequestDispatcher("/likeReplyResponse").forward(req,resp);

--- a/src/main/java/com/xxxx/example/servletLoginGateway.java
+++ b/src/main/java/com/xxxx/example/servletLoginGateway.java
@@ -19,7 +19,7 @@ public class servletLoginGateway extends HttpServlet {
     protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         String username = req.getParameter("username");
         String password = req.getParameter("password");
-        Database myDatabase = new Database("", "DatingAppStaging");
+        Database myDatabase = new Database(System.getenv("DatabaseConnectionString"), System.getenv("DatabaseCollection"));
         Document returnedUser = myDatabase.find_user_by_id(username);
         boolean checkExist = LoginUsernameCheck.check(returnedUser);
         boolean checkPassword = LoginPasswordCheck.check(returnedUser, password);

--- a/src/main/java/com/xxxx/example/servletPostPostGateway.java
+++ b/src/main/java/com/xxxx/example/servletPostPostGateway.java
@@ -15,7 +15,7 @@ public class servletPostPostGateway extends HttpServlet {
     protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         String text = (String) req.getParameter("text");
         String userName = (String) req.getParameter("userName");
-        Database myDatabase = new Database("", "DatingAppStaging");
+        Database myDatabase = new Database(System.getenv("DatabaseConnectionString"), System.getenv("DatabaseCollection"));
         myDatabase.insert_post(userName, text);
         req.getRequestDispatcher("/postPostResponse").forward(req,resp);
     }

--- a/src/main/java/com/xxxx/example/servletRegisterGateway.java
+++ b/src/main/java/com/xxxx/example/servletRegisterGateway.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 public class servletRegisterGateway extends HttpServlet {
     private boolean check;
     protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        Database myDatabase = new Database("", "DatingAppStaging");
+        Database myDatabase = new Database(System.getenv("DatabaseConnectionString"), System.getenv("DatabaseCollection"));
         String username = req.getParameter("username");
         Document returnedUsername = myDatabase.find_user_by_id(username);
         String password = req.getParameter("password");

--- a/src/main/java/com/xxxx/example/servletSendReplyGateway.java
+++ b/src/main/java/com/xxxx/example/servletSendReplyGateway.java
@@ -17,7 +17,7 @@ public class servletSendReplyGateway extends HttpServlet {
         String text = req.getParameter("text");
         String username = req.getParameter("username");
         String id = req.getParameter("id");
-        Database myDatabase = new Database("", "DatingAppStaging");
+        Database myDatabase = new Database(System.getenv("DatabaseConnectionString"), System.getenv("DatabaseCollection"));
         myDatabase.insert_reply(id, username, text);
         req.getRequestDispatcher("/sendReplyResponse").forward(req,resp);
     }

--- a/src/main/java/database_connection/database_usage_example.java
+++ b/src/main/java/database_connection/database_usage_example.java
@@ -27,7 +27,7 @@ public class database_usage_example {
     public static void main(String[] args) {
         // paste in connection string
         // <connection string goes here>
-        Database myDatabase = new Database("<connection string goes here>", "DatingAppStaging");
+        Database myDatabase = new Database(System.getenv("DatabaseConnectionString"), System.getenv("DatabaseCollection"));
 
         //test for insert_post
         myDatabase.insert_post("input_username", "input_post_content");


### PR DESCRIPTION
Using  environmental variable instead of hard code string everywhere.
-Set to use this:
Set env variable in IntelliJ
```
DatabaseCollection=DatingAppStaging
DatabaseConnectionString=<connection string>
```